### PR TITLE
Add Primary Branch header

### DIFF
--- a/freemius-auto-activation.php
+++ b/freemius-auto-activation.php
@@ -3,6 +3,7 @@
 Plugin Name: Freemius Auto Activation
 Plugin URI: https://github.com/squarecandy/freemius-auto-activation
 GitHub Plugin URI: https://github.com/squarecandy/freemius-auto-activation
+Primary Branch: main
 Description: Enables entering Freemius plugin activation codes via wp-config.php
 Version: 1.1.0
 Author: vovafeldman, squarecandy


### PR DESCRIPTION
When the default branch is something other than `master` this header needs to be set for Git Updater.